### PR TITLE
フォームのデザイン編集と詳細一覧画面の調整

### DIFF
--- a/app/controllers/user/joined_events_controller.rb
+++ b/app/controllers/user/joined_events_controller.rb
@@ -1,5 +1,5 @@
 class User::JoinedEventsController < ApplicationController
   def index
-    @joined_events = current_user.joined_events
+    @events = current_user.joined_events.order(created_at: :desc).page(params[:page])
   end
 end

--- a/app/controllers/user/joined_events_controller.rb
+++ b/app/controllers/user/joined_events_controller.rb
@@ -1,5 +1,5 @@
 class User::JoinedEventsController < ApplicationController
   def index
-    @events = current_user.joined_events.order(created_at: :desc).page(params[:page])
+    @joined_events = current_user.joined_events.order(created_at: :desc).page(params[:page])
   end
 end

--- a/app/models/place.rb
+++ b/app/models/place.rb
@@ -4,7 +4,6 @@ class Place < ApplicationRecord
   has_many :events
   validates :place_name, presence: true
   validates :address, presence: true
-  validates :city, presence: true
   validates :latitude, presence: true
   validates :longitude, presence: true
 end

--- a/app/views/events/_event_detail.html.erb
+++ b/app/views/events/_event_detail.html.erb
@@ -1,4 +1,4 @@
-<div class="card card-compact bg-base-100">
+
   <div id="<%= dom_id event %>">
     <% if event.events_image? %>
       <!-- <figure><%# image_tag event.events_image.url %></figure> -->
@@ -88,4 +88,3 @@
       </div>
     </div>
   </div>
-</div>

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -1,38 +1,52 @@
 <%= form_with(model: event, class: "contents") do |form| %>
   <%= render 'shared/error_messages', object: form.object %>
   <div class="my-5">
-    <%= form.label :title %>
-    <%= form.text_field :title, class: "block shadow rounded-md border border-gray-200 outline-none px-3 py-2 mt-2 w-full" %>
+    <%= form.label :title, "タイトル(必須)", calss: "text-gray-800" %>
+    <%= form.text_field :title, class: "w-full bg-gray-50 text-gray-800 border focus:ring ring-indigo-300 rounded outline-none transition duration-100 px-3 py-2 mt-2" %>
   </div>
-
+    
   <div class="my-5">
-    <%= form.label :body %>
-    <%= form.text_area :body, class: "block shadow rounded-md border border-gray-200 outline-none px-3 py-2 mt-2 w-full" %>
+    <%= form.label :date, "開催日時(必須)", calss: "text-gray-800" %>
+    <%= form.datetime_field :date, class: "w-full bg-gray-50 text-gray-800 border focus:ring ring-indigo-300 rounded outline-none transition duration-100 px-3 py-2 mt-2" %>
   </div>
-
+    
   <div class="my-5">
-    <%= form.label :events_image %>
-    <%= form.file_field :events_image, class: "block shadow rounded-md border border-gray-200 outline-none px-3 py-2 mt-2 w-full" %>
-  </div>
-
-  <div class="my-5">
-    <%= form.label :date %>
-    <%= form.datetime_field :date, class: "block shadow rounded-md border border-gray-200 outline-none px-3 py-2 mt-2 w-full" %>
-  </div>
-
-  <div class="my-5">
-    <%= form.label :member %>
+    <%= form.label :member, "募集人数", calss: "text-gray-800" %>
     <%= form.number_field :member,
       in: 1..99,
-      class: "block shadow rounded-md border border-gray-200 outline-none px-3 py-2 mt-2 w-full" %>
+      class: "w-full bg-gray-50 text-gray-800 border focus:ring ring-indigo-300 rounded outline-none transition duration-100 px-3 py-2 mt-2" %>
+  </div>
+
+  <div calss="text-gray-800">開催場所</div>
+
+  <div class="my-5 inline-block">
+    <%= form.label :district_id, "地区", calss: "text-gray-400 text-xs" %><br>
+    <%= form.collection_select :district_id, District.all, :id, :name, { include_blank: "地区を選んでください" }, { class: "bg-gray-50 text-gray-800 border focus:ring ring-indigo-300 rounded outline-none transition duration-100 px-3 py-2 mt-2" }  %>
+  </div>
+
+  <div class="my-5 inline-block ml-4">
+    <%= form.label :place_id, calss: "text-gray-400 text-xs" %><br>
+    <%= form.collection_select :place_id, Place.all, :id, :place_name, { include_blank: "開催場所を選択してください" } , { class: "bg-gray-50 text-gray-800 border focus:ring ring-indigo-300 rounded outline-none transition duration-100 px-3 py-2 mt-2" } %>
+  </div>
+
+  <div class="mb-5">
+    <%= form.label :address, "住所(東京都〇〇区以降)", calss: "text-gray-400 text-xs" %>
+    <%= form.text_field :address, class: "w-full bg-gray-50 text-gray-800 border focus:ring ring-indigo-300 rounded outline-none transition duration-100 px-3 py-2 mt-2" %>
+  </div>
+  
+  <div class="my-5">
+    <%= form.label :body, "本文(必須)", calss: "text-gray-800" %>
+    <%= form.text_area :body, class: "w-full h-64 bg-gray-50 text-gray-800 border focus:ring ring-indigo-300 rounded outline-none transition duration-100 px-3 py-2 mt-2" %>
   </div>
 
   <div class="my-5">
-    <%= form.label :place_id %>
-    <%= form.select :place_id, Place.pluck(:place_name,:id) ,class: "block shadow rounded-md border border-gray-200 outline-none px-3 py-2 mt-2 w-full" %>
+    <%= form.label :events_image, calss: "text-gray-800" %>
+    <%= form.file_field :events_image, class: "w-full bg-gray-50 text-gray-800 border focus:ring ring-indigo-300 rounded outline-none transition duration-100 px-3 py-2 mt-2 mb-5" %>
   </div>
 
+
   <div class="inline">
-    <%= form.submit class: "rounded-lg py-3 px-5 bg-blue-600 text-white inline-block font-medium cursor-pointer" %>
+    <%= form.submit class: "inline-block bg-indigo-500 hover:bg-indigo-600 active:bg-indigo-700 focus-visible:ring ring-indigo-300 text-white text-sm md:text-base font-semibold text-center rounded-lg outline-none transition duration-100 px-8 py-3 cursor-pointer" %>
   </div>
+
 <% end %>

--- a/app/views/events/edit.html.erb
+++ b/app/views/events/edit.html.erb
@@ -1,5 +1,5 @@
 <div class="mx-auto md:w-2/3 w-full">
-  <h1 class="font-bold text-4xl">Editing event</h1>
+  <h1 class="font-bold text-4xl">編集フォーム</h1>
 
   <%= render "form", event: @event %>
 

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -1,27 +1,23 @@
-<div class="w-full">
-  <div class="text-center py-10 px-4 sm:px-6 lg:px-8">
+<div class="bg-white py-6 sm:py-8 lg:py-12">
+  <div class="max-w-screen-2xl md:px-8 mx-auto">
     <% if notice.present? %>
       <p class="py-2 px-3 bg-green-50 mb-5 text-green-500 font-medium rounded-lg inline-block" id="notice"><%= notice %></p>
     <% end %>
 
-    <div class="flex justify-between items-center">
-      <h1 class="font-bold text-4xl">イベント一覧</h1>
-      <%= link_to 'New event', new_event_path, class: "rounded-lg py-3 px-5 bg-blue-600 text-white block font-medium" %>
-    </div>
-
-    <%= search_form_for @q, url: events_path do |f| %>
-      <div class="flex justify-center">
-        <div class="flex pt-5">
-          <div>
-            <%= f.search_field :title_or_body_cont, class: 'input input-bordered w-full max-w-xs', placeholder: '検索ワード' %>
-          </div>
-          <div class="col-auto pb-10 pl-5 inline-block">
-            <%= f.submit class: 'btn btn-primary' %>
-          </div>
-        </div>
+    <div class="md:mb-8">
+      <h2 class="text-gray-800 text-2xl lg:text-3xl font-bold text-center mb-4 md:mb-6">イベント一覧</h2>
+      <p class="max-w-screen-md text-gray-500 md:text-lg text-center mx-auto">イベントに参加して仲間を見つけよう！</p>
+      <div class="flex justify-end">
+        <%= link_to 'New event', new_event_path, class: "rounded-lg py-3 px-5 bg-blue-600 text-white font-medium" %>
       </div>
-    <% end %>
-    
+      
+      <%= search_form_for @q, url: events_path, class:"w-full max-w-md flex gap-2 mb-3 sm:mb-5 m-auto" do |f| %>
+        <%= f.search_field :title_or_body_cont, class: "w-full flex-1 bg-gray-white text-gray-800 placeholder-gray-400 border border-gray-300 focus:ring ring-indigo-300 rounded outline-none transition duration-100 px-3 py-2" %>
+
+        <%= f.submit class:"inline-block bg-indigo-500 hover:bg-indigo-600 active:bg-indigo-700 focus-visible:ring ring-indigo-300 text-white text-sm md:text-base font-semibold text-center rounded outline-none transition duration-100 px-8 py-2" %>
+      <% end %>
+    </div>
+        
     <div id="events" class="min-w-full">
       <%= render @events %>
     </div>

--- a/app/views/events/new.html.erb
+++ b/app/views/events/new.html.erb
@@ -3,5 +3,7 @@
 
   <%= render "form", event: @event %>
 
-  <%= link_to 'Back to events', events_path, class: "ml-2 rounded-lg py-3 px-5 bg-gray-100 inline-block font-medium" %>
+  <div class="flex flex-col sm:flex-row sm:justify-center lg:justify-start gap-2.5">
+    <%= link_to 'Back to events', events_path, class: "rounded-lg py-3 px-5 bg-gray-100 inline-block font-medium my-10" %>
+  </div>
 </div>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -1,21 +1,22 @@
-<div class="mx-auto md:w-2/3 w-full flex">
+<div class="mx-auto w-full flex">
   <div class="mx-auto">
-    <% if notice.present? %>
-      <p class="py-2 px-3 bg-green-50 mb-5 text-green-500 font-medium rounded-lg inline-block" id="notice"><%= notice %></p>
-    <% end %>
-
-    <%= render partial: 'event_detail', locals: { event: @event } %>
-  </div>
-  <div>
-    <% if @event.user_id == current_user.id %>
-      <%= link_to '編集', edit_event_path(@event), class: "mt-2 rounded-lg py-3 px-5 bg-gray-100 inline-block font-medium" %>
-      <%= button_to '削除', event_path(@event), method: :delete, form: { data: { turbo_confirm: "削除しますか？" } }, class: "mt-2 rounded-lg py-3 px-5 bg-gray-100 font-medium" %>
-    <% else %>
-      <% if current_user.joined?(@event) %>
-          <%= button_to "参加をキャンセルする", event_join_events_path(@event), method: :delete, form: { data: { turbo_confirm: "イベントの参加をキャンセルしますか？" } } %>
-      <% else %>
-          <%= button_to "参加を申し込む", event_join_events_path(@event), method: :post, form: { data: { turbo_confirm: "イベントに参加しますか？" } } %>
+      <% if notice.present? %>
+        <p class="py-2 px-3 bg-green-50 mb-5 text-green-500 font-medium rounded-lg inline-block" id="notice"><%= notice %></p>
       <% end %>
-    <% end %>
+    <div class="card card-compact bg-base-100">
+      <%= render partial: 'event_detail', locals: { event: @event } %>
+    </div>
+    <div class="flex flex-col sm:flex-row sm:justify-center lg:justify-start gap-2.5">
+      <% if @event.user_id == current_user.id %>
+        <%= link_to '編集', edit_event_path(@event), class: "btn btn-success px-10 mb-5" %>
+        <%= button_to '削除', event_path(@event), method: :delete, form: { data: { turbo_confirm: "削除しますか？" } }, class: "btn btn-error px-10 mb-5" %>
+      <% else %>
+        <% if current_user.joined?(@event) %>
+          <%= button_to "参加をキャンセルする", event_join_events_path(@event), method: :delete, form: { data: { turbo_confirm: "イベントの参加をキャンセルしますか？" } }, class: "btn btn-secondary mb-5" %>
+        <% else %>
+          <%= button_to "参加を申し込む", event_join_events_path(@event), method: :post, form: { data: { turbo_confirm: "イベントに参加しますか？",turbo_post: :post } }, class: "btn btn-primary mb-5" %>
+        <% end %>
+      <% end %>
+    </div>
   </div>
 </div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -14,7 +14,7 @@
           <li><%= link_to "ホーム", root_path %></li>
           <li><%= link_to "イベント一覧", events_path %></li>
           <li><%= link_to "プロフィール", profile_path %></li>
-          <li><%= link_to "参加イベント一覧", events_path %></li>
+          <li><%= link_to "参加イベント一覧", user_joined_events_path(current_user) %></li>
           <li><%= button_to t('defaults.logout'), logout_path, method: :delete, data: { turbo: false } %><li>
         </ul>
       </div>

--- a/app/views/user/joined_events/_joined_event.html.erb
+++ b/app/views/user/joined_events/_joined_event.html.erb
@@ -1,3 +1,0 @@
-<%= joined_event.title %>
-<%= joined_event.body %>
-<%= link_to 'イベントを確認',event_path(joined_event), class:"btn btn-primary" %>

--- a/app/views/user/joined_events/index.html.erb
+++ b/app/views/user/joined_events/index.html.erb
@@ -1,6 +1,18 @@
-<div class="container mx-auto">
-  <h1 class="font-bold text-4xl">参加したイベント一覧</h1>
-  <div>
-    <%= render partial: 'user/joined_events/joined_event', collection: @joined_events %>
+<div class="bg-white py-6 sm:py-8 lg:py-12">
+  <div class="max-w-screen-2xl md:px-8 mx-auto">
+    <% if notice.present? %>
+      <p class="py-2 px-3 bg-green-50 mb-5 text-green-500 font-medium rounded-lg inline-block" id="notice"><%= notice %></p>
+    <% end %>
+
+    <div class="md:mb-8 border-t-2">
+      <h2 class="text-gray-800 text-2xl lg:text-3xl font-bold text-center mb-4 md:mb-6 mt-10">参加イベント一覧</h2>
+      <p class="max-w-screen-md text-gray-500 md:text-lg text-center mx-auto"></p>
+      <div class="flex justify-end">
+        <%= link_to 'New event', new_event_path, class: "rounded-lg py-3 px-5 bg-blue-600 text-white font-medium" %>
+      </div>
+    
+    <div id="events" class="min-w-full">
+      <%= render partial: 'events/event', collection: @events %>
+    </div>
   </div>
 </div>

--- a/app/views/user/joined_events/index.html.erb
+++ b/app/views/user/joined_events/index.html.erb
@@ -12,7 +12,7 @@
       </div>
     
     <div id="events" class="min-w-full">
-      <%= render partial: 'events/event', collection: @events %>
+      <%= render partial: 'events/event', collection: @joined_events, as: 'event' %>
     </div>
   </div>
 </div>


### PR DESCRIPTION
今回はフォーム系のデザイン修正を主に行っています。

また、参加イベント一覧のデザインも新たに手をつけており、
それに伴ってコントローラーやヘッダリンク等も修正しています。
なお、参加イベント一覧の上部には、ユーザー情報が入る予定なのでボーダーを引いています。

先にpushした詳細一覧の画面で、一部ボタンの位置がおかしかった点の修正も行っています。
ただ、一覧画面で最初の記事が一段下がってしまうところが修正できませんでした、Fixを永田さんにお願いしたいです。。

フォームのjqueryはこれから取り掛かって次にpushする予定ですので、少々お待ちください！